### PR TITLE
Reverse events list to have newest on the top

### DIFF
--- a/src/js/components/Timeline.js
+++ b/src/js/components/Timeline.js
@@ -35,7 +35,7 @@ Vue.component('timeline', {
 
       axios.get('/data/events.json')
         .then(response => {
-          this.events = response.data;
+          this.events = response.data.reverse();
           this.last_modified = new Date(response.headers['last-modified']);
           callback();
         }).catch((e) => {


### PR DESCRIPTION
IMHO the list of events should be displayed in a reverse order to keep the latest events on the top.